### PR TITLE
Do not escape the POST body

### DIFF
--- a/hurl.rb
+++ b/hurl.rb
@@ -147,8 +147,8 @@ module Hurl
       add_headers_from_arrays(curl, params["header-keys"], params["header-vals"])
 
       # arbitrary post params
-      if params['post-body']
-        post_data = Array(params['post-body'])
+      if params['post-body'] && ['POST', 'PUT'].index(method)
+        post_data = [params['post-body']]
       else
         post_data = make_fields(method, params["param-keys"], params["param-vals"])
       end

--- a/hurl.rb
+++ b/hurl.rb
@@ -148,7 +148,7 @@ module Hurl
 
       # arbitrary post params
       if params['post-body']
-        post_data = Array(Rack::Utils.escape params['post-body'])
+        post_data = Array(params['post-body'])
       else
         post_data = make_fields(method, params["param-keys"], params["param-vals"])
       end


### PR DESCRIPTION
The POST (or PUT) body is currently URL-encoded through Rack::Utils.escape. This disallows sending raw XML or JSON in the body, defeating the point of a raw body.
