### PR TITLE
Allow defaults to be passed in to the form

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -49,7 +49,7 @@ module Hurl
     end
 
     get '/' do
-      @hurl = {}
+      @hurl = params
       mustache :index
     end
 


### PR DESCRIPTION
This very minor change initialises the default @hurl with params instead of {} so that we can pass some values in and pre-populate the fields. This makes it a lot easier to send people examples of how to use an API call.

For example:

http://hurl.it/?url=http%3A%2F%2Fapi.pachube.com%2Ffeeds.json&header-keys[]=X-PachubeApiKey&header-vals[]=dshajfbds&method=POST&post-body=%3Csome%3E%0A%20%20%3Ccontent%3E%0A%20%20%3C%2Fcontent%3E%0A%3C%2Fsome%3E%0A

(if this were running on hurl.it of course)
